### PR TITLE
Deprecation fixes

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,7 +1,6 @@
 name: Mac Build
 
-on: 
-  workflow_dispatch:
+on: workflow_dispatch:
 
 jobs:
   build-macos:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,6 +1,6 @@
 name: Mac Build
 
-on: [push]
+on: workflow_dispatch:
 
 jobs:
   build-macos:

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -17,8 +17,4 @@ jobs:
       run: cmake --build build
     - name: test
       run: cd build && ctest
-    - name: Upload RapidLibPlugin build artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: RapidLibPlugin
-        path: build/
+ 

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -18,4 +18,8 @@ jobs:
       run: cmake --build build
     - name: test
       run: cd build && ctest
- 
+    - name: Upload RapidLibPlugin build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: RapidLibPlugin
+        path: build/

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,6 +1,7 @@
 name: Mac Build
 
-on: workflow_dispatch:
+on: 
+  workflow_dispatch:
 
 jobs:
   build-macos:

--- a/dependencies/jsoncpp.cpp
+++ b/dependencies/jsoncpp.cpp
@@ -4206,7 +4206,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
   int len = -1;
 
   char formatString[6];
-  sprintf(formatString, "%%.%dg", precision);
+  snprintf(formatString, sizeof(formatString), "%%.%dg", precision);
 
   // Print into the buffer. We need not request the alternative representation
   // that always has a decimal point because JSON doesn't distingish the

--- a/dependencies/libsvm/libsvm.cpp
+++ b/dependencies/libsvm/libsvm.cpp
@@ -52,7 +52,7 @@ namespace LIBSVM {
         char buf[BUFSIZ];
         va_list ap;
         va_start(ap,fmt);
-        vsprintf(buf,fmt,ap);
+        vsnprintf(buf, sizeof(buf), fmt, ap);
         va_end(ap);
         (*svm_print_string)(buf);
     }


### PR DESCRIPTION
The updates 
- [Update libsvm.cpp with vsnprintf]
- [Update jsoncpp.cpp with snprintf]
will fix depreciation errors. 
The changes to the yaml files are for test to compile & download the artifacts. 
I tried to revert them but would be nice to convert them auto-releases.
Thanks for the great library, hope to use it on Unity 6 and Max/MSP 9