### PR TITLE
Allow to disable jsoncpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.DS_STORE
 /wekiLib/
 
 # Created by https://www.gitignore.io/api/emacs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ else()
     add_compile_options(-std=c++20 -O2)   
 endif()
 
+option(RAPIDLIB_DISABLE_JSONCPP "Disable jsoncpp integration." OFF)
+if(EMSCRIPTEN)
+		set(RAPIDLIB_DISABLE_JSONCPP ON)
+endif()
+
 # Threads
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -28,15 +33,20 @@ file(GLOB JSON_SRC "${PROJECT_SOURCE_DIR}/dependencies/jsoncpp.cpp")
 file(GLOB BAYES_SRC "${PROJECT_SOURCE_DIR}/dependencies/bayesfilter/src/*.cpp")
 
 # Set the source for the main library, using the groups defined above
-set(RAPIDLIB_FULL_SRC 
+set(RAPIDLIB_FULL_SRC
 		${RAPIDLIB_SRC}
 		${RAPIDLIB_DEP}
-		${JSON_SRC}
 		${BAYES_SRC}
-	)
+  )
 
 add_library(${PROJECT_NAME} SHARED ${RAPIDLIB_FULL_SRC})
 add_executable(rapidLibTest test/rapidLibTest.cpp)
+
+if(RAPIDLIB_DISABLE_JSONCPP)
+		target_compile_definitions(${PROJECT_NAME} PUBLIC RAPIDLIB_DISABLE_JSONCPP)
+else()
+		target_sources(${PROJECT_NAME} PUBLIC ${JSON_SRC})
+endif()
 
 #include(GenerateExportHeader)
 #generate_export_header(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(rapidLibTest test/rapidLibTest.cpp)
 if(RAPIDLIB_DISABLE_JSONCPP)
 		target_compile_definitions(${PROJECT_NAME} PUBLIC RAPIDLIB_DISABLE_JSONCPP)
 else()
-		target_sources(${PROJECT_NAME} PUBLIC ${JSON_SRC})
+		target_sources(${PROJECT_NAME} PRIVATE ${JSON_SRC})
 endif()
 
 #include(GenerateExportHeader)
@@ -56,3 +56,4 @@ target_link_libraries(rapidLibTest Threads::Threads)
 
 enable_testing()
 add_test(rapidLibTest rapidLibTest)
+

--- a/dependencies/jsoncpp.cpp
+++ b/dependencies/jsoncpp.cpp
@@ -1767,8 +1767,8 @@ bool OurReader::decodeNumber(Token& token, Value& decoded) {
     ++current;
   // TODO: Help the compiler do the div and mod at compile time or get rid of them.
   Value::LargestUInt maxIntegerValue =
-      isNegative ? Value::LargestUInt(-Value::minLargestInt)
-                 : Value::maxLargestUInt;
+        isNegative ? Value::LargestUInt(Value::maxLargestInt) + 1
+                   : Value::maxLargestUInt;
   Value::LargestUInt threshold = maxIntegerValue / 10;
   Value::LargestUInt value = 0;
   while (current < token.end_) {

--- a/src/baseModel.h
+++ b/src/baseModel.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include "trainingExample.h"
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 #include "../dependencies/json/json.h"
 #endif
 
@@ -49,7 +49,7 @@ public:
     virtual size_t getNumInputs() const = 0;
     virtual std::vector<size_t> getWhichInputs() const = 0;
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
     virtual void getJSONDescription(Json::Value& currentModel) = 0;
 
 protected:

--- a/src/classification.cpp
+++ b/src/classification.cpp
@@ -69,36 +69,39 @@ bool classificationTemplate<T>::train(const std::vector<trainingExampleTemplate<
   if (training_set.size() > 0)
   {
     //create model(s) here
-    modelSet<T>::numInputs = int(training_set[0].input.size());
-    modelSet<T>::numOutputs = int(training_set[0].output.size());
-    
-    for (int i = 0; i < modelSet<T>::numInputs; ++i)
+    modelSet<T>::numInputs = static_cast<int>(training_set[0].input.size());
+    modelSet<T>::numOutputs = static_cast<int>(training_set[0].output.size());
+
+    for (int i {}; i < modelSet<T>::numInputs; ++i)
     {
       modelSet<T>::inputNames.push_back("inputs-" + std::to_string(i + 1));
     }
-    modelSet<T>::numOutputs = int(training_set[0].output.size());
-    
-    for ( auto example : training_set)
+
+    modelSet<T>::numOutputs = static_cast<int>(training_set[0].output.size());
+
+    for (const auto& example : training_set)
     {
       if (example.input.size() != modelSet<T>::numInputs)
       {
         throw std::length_error("unequal feature vectors in input.");
         return false;
       }
+
       if (example.output.size() != modelSet<T>::numOutputs)
       {
         throw std::length_error("unequal output vectors.");
         return false;
       }
     }
-    std::vector<size_t> whichInputs;
-    
-    for (int j = 0; j < modelSet<T>::numInputs; ++j)
+
+    std::vector<size_t> whichInputs {};
+
+    for (int inputNum {}; inputNum < modelSet<T>::numInputs; ++inputNum)
     {
-      whichInputs.push_back(j);
+      whichInputs.push_back(inputNum);
     }
     
-    for (int i = 0; i < modelSet<T>::numOutputs; ++i)
+    for (int outputNum {}; outputNum < modelSet<T>::numOutputs; ++outputNum)
     {
       if (classificationType == svm)
       {
@@ -118,12 +121,13 @@ bool classificationTemplate<T>::train(const std::vector<trainingExampleTemplate<
 template<typename T>
 std::vector<int> classificationTemplate<T>::getK()
 {
-  std::vector<int> kVector;
-  
+  std::vector<int> kVector {};
+
   for (const baseModel<T>* model : modelSet<T>::myModelSet)
   {
     kVector.push_back(dynamic_cast<const knnClassification<T>*>(model)->getK()); //FIXME: I really dislike this design
   }
+
   return kVector;
 }
 

--- a/src/classification.cpp
+++ b/src/classification.cpp
@@ -6,9 +6,10 @@
 //  Copyright © 2016 Goldsmiths. All rights reserved.
 //
 
-
-#include <vector>
 #include "classification.h"
+
+#include <stdexcept>
+#include <vector>
 #ifdef EMSCRIPTEN
 #include "emscripten/classificationEmbindings.h"
 #endif

--- a/src/dtw.cpp
+++ b/src/dtw.cpp
@@ -22,26 +22,28 @@ dtw<T>::~dtw() {};
 template<typename T>
 inline T dtw<T>::distanceFunction(const std::vector<T> &x, const std::vector<T> &y)
 {
-  double euclidianDistance = 0;
+  double euclidianDistance {};
+
   if (x.size() != y.size())
   {
     throw std::length_error("comparing different length series");
   }
   else
   {
-    for (std::size_t i = 0; i < x.size(); ++i)
+    for (std::size_t i {}; i < x.size(); ++i)
     {
-      euclidianDistance = euclidianDistance + pow((x[i] - y[i]), 2);
+      euclidianDistance += std::pow((x[i] - y[i]), 2);
     }
     
     euclidianDistance = sqrt(euclidianDistance);
   }
-  return (T)euclidianDistance;
+
+  return static_cast<T>(euclidianDistance);
 };
 
 /* Just returns the cost, doesn't calculate the path */
 template<typename T>
-T dtw<T>::getCost(const std::vector<std::vector<T> > &seriesX, const std::vector<std::vector<T> > &seriesY)
+T dtw<T>::getCost(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T>>& seriesY)
 {
   if (seriesX.size() < seriesY.size()) return getCost(seriesY, seriesX);
   
@@ -53,22 +55,23 @@ T dtw<T>::getCost(const std::vector<std::vector<T> > &seriesX, const std::vector
   
   //Calculate values for the first column
   costMatrix[0][0] = distanceFunction(seriesX[0], seriesY[0]);
-  for (int j = 1; j <= maxY; ++j) 
+  for (int y { 1 }; y <= maxY; ++y)
   {
-    costMatrix[0][j] = costMatrix[0][j - 1] + distanceFunction(seriesX[0], seriesY[j]);
+    costMatrix[0][y] = costMatrix[0][y - 1] + distanceFunction(seriesX[0], seriesY[y]);
   }
   
-  for (std::size_t i = 1; i <= maxX; ++i)
+  for (std::size_t x { 1 }; x <= maxX; ++x)
   {
     //Bottom row of current column
-    costMatrix[i][0] = costMatrix[i - 1][0] + distanceFunction(seriesX[i], seriesY[0]);
-    
-    for (std::size_t j = 1; j <= maxY; ++j)
+    costMatrix[x][0] = costMatrix[x - 1][0] + distanceFunction(seriesX[x], seriesY[0]);
+
+    for (std::size_t y { 1 }; y <= maxY; ++y)
     {
-      T minGlobalCost = fmin(costMatrix[i-1][j-1], costMatrix[i][j-1]);
-      costMatrix[i][j] = minGlobalCost + distanceFunction(seriesX[i], seriesY[j]);
+      T minGlobalCost { fmin(costMatrix[x - 1][y - 1], costMatrix[x][y - 1]) };
+      costMatrix[x][y] = minGlobalCost + distanceFunction(seriesX[x], seriesY[y]);
     }
   }
+
   return costMatrix[maxX][maxY];
 };
 
@@ -76,38 +79,38 @@ template<typename T>
 warpPath dtw<T>::calculatePath(std::size_t seriesXsize, std::size_t seriesYsize) const
 {
   warpPath warpPath;
-  std::size_t i { seriesXsize - 1 };
-  std::size_t j { seriesYsize - 1 };
-  warpPath.add(i, j);
-  
-  while ((i > 0) || (j > 0))
+  std::size_t x { seriesXsize - 1 };
+  std::size_t y { seriesYsize - 1 };
+  warpPath.add(x, y);
+
+  while ((x > 0) || (y > 0))
   {
-    T diagonalCost = ((i > 0) && (j > 0)) ? costMatrix[i - 1][j - 1] : std::numeric_limits<T>::infinity();
-    T leftCost = (i > 0) ? costMatrix[i - 1][j] : std::numeric_limits<T>::infinity();
-    T downCost = (j > 0) ? costMatrix[i][j - 1] : std::numeric_limits<T>::infinity();
-    
+    T diagonalCost { ((x > 0) && (y > 0)) ? costMatrix[x - 1][y - 1] : std::numeric_limits<T>::infinity() };
+    T leftCost { (x > 0) ? costMatrix[x - 1][y] : std::numeric_limits<T>::infinity() };
+    T downCost { (y > 0) ? costMatrix[x][y - 1] : std::numeric_limits<T>::infinity() };
+
     if ((diagonalCost <= leftCost) && (diagonalCost <= downCost))
     {
-      if (i > 0) --i;
-      if (j > 0) --j;
+      if (x > 0) --x;
+      if (y > 0) --y;
     }
     else if ((leftCost < diagonalCost) && (leftCost < downCost))
     {
-      --i;
+      --x;
     }
     else if ((downCost < diagonalCost) && (downCost < leftCost))
     {
-      --j;
+      --y;
     }
-    else if (i <= j)
+    else if (x <= y)
     {
-      --j;
+      --y;
     }
     else
     {
-      --i;
+      --x;
     }
-    warpPath.add(i, j);
+    warpPath.add(x, y);
   }
   
   return warpPath;
@@ -115,9 +118,10 @@ warpPath dtw<T>::calculatePath(std::size_t seriesXsize, std::size_t seriesYsize)
 
 /* calculates both the cost and the warp path*/
 template<typename T>
-warpInfo<T> dtw<T>::dynamicTimeWarp(const std::vector<std::vector<T> > &seriesX, const std::vector<std::vector<T> > &seriesY)
+warpInfo<T> dtw<T>::dynamicTimeWarp(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T>>& seriesY)
 {
-  warpInfo<T> info;
+  warpInfo<T> info {};
+
   //calculate cost matrix
   info.cost = getCost(seriesX, seriesY);
   info.path = calculatePath(seriesX.size(), seriesY.size());
@@ -132,26 +136,34 @@ warpInfo<T> dtw<T>::constrainedDTW(const std::vector<std::vector<T> > &seriesX, 
   costMatrix.clear();
   std::vector<T> tempVector(seriesY.size(), std::numeric_limits<T>::max());
   costMatrix.assign(seriesX.size(), tempVector); //TODO: this could be smaller, since most cells are unused
-  std::size_t maxX = seriesX.size() - 1;
-  std::size_t maxY = seriesY.size() - 1;
-  
+  std::size_t maxX { seriesX.size() - 1 };
+  std::size_t maxY { seriesY.size() - 1 };
+
   //fill cost matrix cells based on window
-  for (std::size_t currentX = 0; currentX < window.minMaxValues.size(); ++currentX)
+  for (std::size_t currentX {}; currentX < window.minMaxValues.size(); ++currentX)
   {
-    for (std::size_t currentY = window.minMaxValues[currentX].first; currentY <= window.minMaxValues[currentX].second; ++currentY) //FIXME: should be <= ?
+    for (std::size_t currentY { window.minMaxValues[currentX].first }; currentY <= window.minMaxValues[currentX].second; ++currentY) //FIXME: should be <= ?
     {
-      if (currentX == 0 && currentY == 0) { //bottom left cell
+      if (currentX == 0 && currentY == 0)  //bottom left cell
+      {
         costMatrix[0][0] = distanceFunction(seriesX[0], seriesY[0]);
-      } else if (currentX == 0) { //first column
+      }
+      else if (currentX == 0) //first column
+      {
         costMatrix[0][currentY] = distanceFunction(seriesX[0], seriesY[currentY]) + costMatrix[0][currentY - 1];
-      } else if (currentY == 0) { //first row
+      }
+      else if (currentY == 0) //first row
+      {
         costMatrix[currentX][0] = distanceFunction(seriesX[currentX], seriesY[0]) + costMatrix[currentX - 1][0];
-      } else {
-        T minGlobalCost = fmin(costMatrix[currentX - 1][currentY], fmin(costMatrix[currentX-1][currentY-1], costMatrix[currentX][currentY-1]));
+      }
+      else
+      {
+        T minGlobalCost { fmin(costMatrix[currentX - 1][currentY], fmin(costMatrix[currentX-1][currentY-1], costMatrix[currentX][currentY-1])) };
         costMatrix[currentX][currentY] = distanceFunction(seriesX[currentX], seriesY[currentY]) + minGlobalCost;
       }
     }
   }
+  
   warpInfo<T> info;
   info.cost = costMatrix[maxX][maxY];
   info.path = calculatePath(seriesX.size(), seriesY.size());

--- a/src/dtw.cpp
+++ b/src/dtw.cpp
@@ -67,7 +67,7 @@ T dtw<T>::getCost(const std::vector<std::vector<T>>& seriesX, const std::vector<
 
     for (std::size_t y { 1 }; y <= maxY; ++y)
     {
-      T minGlobalCost { fmin(costMatrix[x - 1][y - 1], costMatrix[x][y - 1]) };
+      T minGlobalCost { (std::min(costMatrix[x - 1][y - 1], costMatrix[x][y - 1])) };
       costMatrix[x][y] = minGlobalCost + distanceFunction(seriesX[x], seriesY[y]);
     }
   }
@@ -158,7 +158,7 @@ warpInfo<T> dtw<T>::constrainedDTW(const std::vector<std::vector<T> > &seriesX, 
       }
       else
       {
-        T minGlobalCost { fmin(costMatrix[currentX - 1][currentY], fmin(costMatrix[currentX-1][currentY-1], costMatrix[currentX][currentY-1])) };
+        T minGlobalCost { std::min(costMatrix[currentX - 1][currentY], std::min(costMatrix[currentX-1][currentY-1], costMatrix[currentX][currentY-1])) };
         costMatrix[currentX][currentY] = distanceFunction(seriesX[currentX], seriesY[currentY]) + minGlobalCost;
       }
     }

--- a/src/fastDTW.cpp
+++ b/src/fastDTW.cpp
@@ -20,7 +20,7 @@ template<typename T>
 warpInfo<T> fastDTW<T>::fullFastDTW(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T >>& seriesY, int searchRadius)
 {
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
   if (seriesY.size() > seriesX.size())
   {
     return fullFastDTW(seriesY, seriesX, searchRadius); //TODO: I'm not sure why I need this. Also, not sure why it fails with Emscripten.

--- a/src/fastDTW.cpp
+++ b/src/fastDTW.cpp
@@ -17,64 +17,73 @@ template<typename T>
 fastDTW<T>::~fastDTW() {};
 
 template<typename T>
-warpInfo<T> fastDTW<T>::fullFastDTW(const std::vector<std::vector<T>> &seriesX, const std::vector<std::vector<T > > &seriesY, int searchRadius)
+warpInfo<T> fastDTW<T>::fullFastDTW(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T >>& seriesY, int searchRadius)
 {
-   
+
 #ifndef EMSCRIPTEN
-    if (seriesY.size() > seriesX.size()) 
-    {
-        return fullFastDTW(seriesY, seriesX, searchRadius); //TODO: I'm not sure why I need this. Also, not sure why it fails with Emscripten.
-    }
+  if (seriesY.size() > seriesX.size())
+  {
+    return fullFastDTW(seriesY, seriesX, searchRadius); //TODO: I'm not sure why I need this. Also, not sure why it fails with Emscripten.
+  }
 #endif
-    
-    dtw<T> dtw;
-    searchRadius = (searchRadius < 0) ? 0 : searchRadius;
-    int minSeries = searchRadius + 2;
-    if (seriesX.size() <= minSeries || seriesY.size() <= minSeries) 
+
+  dtw<T> dtw;
+  searchRadius = std::max(0, searchRadius);
+  const int minSeries { searchRadius + 2 };
+
+  if (seriesX.size() <= minSeries || seriesY.size() <= minSeries)
+  {
+    return dtw.dynamicTimeWarp(seriesX, seriesY);
+  }
+
+  T resolution { 2.0 };//TODO: Just hardcode this?
+  std::vector<std::vector<T>> shrunkenX { downsample(seriesX, resolution) };
+  std::vector<std::vector<T>> shrunkenY { downsample(seriesY, resolution) };
+
+  //some nice recursion here
+  searchWindow<T> window(int(seriesX.size()), int(seriesY.size()), getWarpPath(shrunkenX, shrunkenY, searchRadius), searchRadius);
+
+  return dtw.constrainedDTW(seriesX, seriesY, window);
+};
+
+template<typename T>
+T fastDTW<T>::getCost(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T>>& seriesY, int searchRadius)
+{
+  warpInfo<T> info { fullFastDTW(seriesX, seriesY, searchRadius) };
+  return info.cost;
+};
+
+template<typename T>
+warpPath fastDTW<T>::getWarpPath(const std::vector<std::vector<T>>& seriesX, const std::vector<std::vector<T>>& seriesY, int searchRadius)
+{
+  warpInfo<T> info { fullFastDTW(seriesX, seriesY, searchRadius) };
+  return info.path;
+};
+
+template<typename T>
+inline std::vector<std::vector<T> > fastDTW<T>::downsample(const std::vector<std::vector<T>>& series, T resolution)
+{
+  std::vector<std::vector<T> > shrunkenSeries {};
+
+  for (std::size_t i {}; i < series.size(); ++i)
+  {
+    if (i % 2 == 0)
     {
-        return dtw.dynamicTimeWarp(seriesX, seriesY);
+      shrunkenSeries.push_back(series[i]);
     }
-    
-    T resolution = 2.0;//TODO: Just hardcode this?
-    std::vector<std::vector<T>> shrunkenX = downsample(seriesX, resolution);
-    std::vector<std::vector<T>> shrunkenY = downsample(seriesY, resolution);
-    
-    //some nice recursion here
-    searchWindow<T> window(int(seriesX.size()), int(seriesY.size()), getWarpPath(shrunkenX, shrunkenY, searchRadius), searchRadius);
-    return dtw.constrainedDTW(seriesX, seriesY, window);
-};
+    else
+    {
+      const int shrunkIndex { static_cast<int>(i * 0.5) };
 
-template<typename T>
-T fastDTW<T>::getCost(const std::vector<std::vector<T>> &seriesX, const std::vector<std::vector<T > > &seriesY, int searchRadius)
-{
-    warpInfo<T> info = fullFastDTW(seriesX, seriesY, searchRadius);
-    return info.cost;
-};
-
-template<typename T>
-warpPath fastDTW<T>::getWarpPath(const std::vector<std::vector<T>> &seriesX, const std::vector<std::vector<T > > &seriesY, int searchRadius)
-{
-    warpInfo<T> info = fullFastDTW(seriesX, seriesY, searchRadius);
-    return info.path;
-};
-
-template<typename T>
-inline std::vector<std::vector<T> > fastDTW<T>::downsample(const std::vector<std::vector<T>> &series, T resolution) 
-{
-    std::vector<std::vector<T> > shrunkenSeries;
-    
-    for (std::size_t i = 0; i < series.size(); ++i) {
-        if (i % 2 == 0) {
-            shrunkenSeries.push_back(series[i]);
-        } else {
-            int shrunkIndex = int(i * 0.5);
-            for (std::size_t j = 0; j < series[i].size(); ++j) {
-                shrunkenSeries[shrunkIndex][j] = (shrunkenSeries[shrunkIndex][j] + series[i][j]) * (T)0.5;
-            }
-        }
+      for (std::size_t j {}; j < series[i].size(); ++j)
+      {
+        shrunkenSeries[shrunkIndex][j] = (shrunkenSeries[shrunkIndex][j] + series[i][j]) * (T)0.5;
+      }
     }
-    //TODO: implement downsampling by resolution
-    return shrunkenSeries;
+  }
+  
+  //TODO: implement downsampling by resolution
+  return shrunkenSeries;
 }
 
 //explicit instantiation

--- a/src/knnClassification.cpp
+++ b/src/knnClassification.cpp
@@ -7,9 +7,11 @@
 //
 
 #include "knnClassification.h"
+
+#include <cmath>
+
 #include <algorithm>
 #include <map>
-#include <math.h>
 #include <utility>
 #include <vector>
 #ifdef EMSCRIPTEN
@@ -174,7 +176,7 @@ T knnClassification<T>::run(const std::vector<T> &inputVector)
   return foundClass;
 }
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 template <typename T>
 void knnClassification<T>::getJSONDescription(Json::Value &jsonModelDescription)
 {

--- a/src/knnClassification.h
+++ b/src/knnClassification.h
@@ -18,82 +18,84 @@
 
 /** Class for implementing a knn classifier */
 template<typename T>
-class knnClassification final : public baseModel<T> 
-{    
-public:
-    /** Constructor that takes training examples in
-     * @param int Number of inputs expected in the training and input vectors
-     * @param vector of input numbers to be fed into the classifer.
-     * @param vector of training examples
-     * @param int how many near neighbours to evaluate
-     */
-    knnClassification(const int &num_inputs,
-                      const std::vector<size_t> &which_inputs,
-                      const std::vector<trainingExampleTemplate<T> > &trainingSet,
-                      const int k);
-    ~knnClassification();
-    
-    /** add another example to the existing training set
-     * @param class number of example
-     * @param feature vector of example
-     */
-    void addNeighbour(const int &classNum, const std::vector<T> &features);
-    
-    /** Generate an output value from a single input vector.
-     * @param A standard vector of type T to be evaluated.
-     * @return A single value of type T: the nearest class as determined by k-nearest neighbor.
-     */
-    T run(const std::vector<T> &inputVector) override;
-    
-    /** Fill the model with a vector of examples.
-     *
-     * @param The training set is a vector of training examples that contain both a vector of input values and a value specifying desired output class.
-     *
-     */
-    void train(const std::vector<trainingExampleTemplate<T> > &trainingSet) override;
+class knnClassification final : public baseModel<T>
+{
+  public:
+  /** Constructor that takes training examples in
+   * @param int Number of inputs expected in the training and input vectors
+   * @param vector of input numbers to be fed into the classifer.
+   * @param vector of training examples
+   * @param int how many near neighbours to evaluate
+   */
+  knnClassification(const int &num_inputs,
+                    const std::vector<size_t> &which_inputs,
+                    const std::vector<trainingExampleTemplate<T> > &trainingSet,
+                    const int k);
 
-    /** Fill the model with a vector of examples. Use this when the model is part of a modelSet.
-     *
-     * @param The training set is a vector of training examples that contain both a vector of input values and a value specifying desired output class.
-     *
-     */
-    void train(const std::vector<trainingExampleTemplate<T> >& trainingSet, const std::size_t whichOutput) override;
-    
-    /** Reset the model to its empty state. */
-    void reset() override;
-    
-    /** Find out how many inputs the model expects
-     * @return Integer number of intpus
-     */
-    size_t getNumInputs() const override;
-    
-    /** Find out which inputs in a vector will be used
-     * @return Vector of ints, specifying input indices.
-     */
-    std::vector<size_t> getWhichInputs() const override;
-    
-    /** Get the number of nearest neighbours used by the kNN algorithm. */
-    int getK() const;
-    /** Change the number of nearest neighbours used by the kNN algorithm.
-     * @param new value for k
-     */
-    void setK(int newK);
-    
+  ~knnClassification();
+
+  /** add another example to the existing training set
+   * @param class number of example
+   * @param feature vector of example
+   */
+  void addNeighbour(const int classNum, const std::vector<T>& features);
+
+  /** Generate an output value from a single input vector.
+   * @param A standard vector of type T to be evaluated.
+   * @return A single value of type T: the nearest class as determined by k-nearest neighbor.
+   */
+  T run(const std::vector<T>& inputVector) override;
+
+  /** Fill the model with a vector of examples.
+   *
+   * @param The training set is a vector of training examples that contain both a vector of input values and a value specifying desired output class.
+   *
+   */
+  void train(const std::vector<trainingExampleTemplate<T> >& trainingSet) override;
+
+  /** Fill the model with a vector of examples. Use this when the model is part of a modelSet.
+   *
+   * @param The training set is a vector of training examples that contain both a vector of input values and a value specifying desired output class.
+   *
+   */
+  void train(const std::vector<trainingExampleTemplate<T>>& trainingSet, const std::size_t whichOutput) override;
+
+  /** Reset the model to its empty state. */
+  void reset() override;
+
+  /** Find out how many inputs the model expects
+   * @return Integer number of intpus
+   */
+  size_t getNumInputs() const override;
+
+  /** Find out which inputs in a vector will be used
+   * @return Vector of ints, specifying input indices.
+   */
+  std::vector<size_t> getWhichInputs() const override;
+
+  /** Get the number of nearest neighbours used by the kNN algorithm. */
+  int getK() const;
+
+  /** Change the number of nearest neighbours used by the kNN algorithm.
+   * @param new value for k
+   */
+  void setK(int newK);
+
 #ifndef EMSCRIPTEN
-    /** Populate a JSON value with a description of the current model
-     * @param A JSON value to be populated
-     */
-    void getJSONDescription(Json::Value &currentModel) override;
+  /** Populate a JSON value with a description of the current model
+   * @param A JSON value to be populated
+   */
+  void getJSONDescription(Json::Value& currentModel) override;
 #endif
-    
-private:
-    int numInputs;
-    std::vector<size_t> whichInputs;
-    std::size_t whichOutput;
-    std::vector<trainingExampleTemplate<T>> neighbours;
-    int desiredK; //K that user asked for might be limited but number of examples
-    int currentK; //K minimum of desiredK or neighbours.size()
-    inline void updateK();
+
+  private:
+  int numInputs {};
+  std::vector<size_t> whichInputs {};
+  std::size_t whichOutput {};
+  std::vector<trainingExampleTemplate<T>> neighbours {};
+  int desiredK {}; //K that user asked for might be limited but number of examples
+  int currentK {}; //K minimum of desiredK or neighbours.size()
+  inline void updateK();
 };
 
 #endif

--- a/src/knnClassification.h
+++ b/src/knnClassification.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "baseModel.h"
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 #include "../dependencies/json/json.h"
 #endif
 
@@ -81,7 +81,7 @@ class knnClassification final : public baseModel<T>
    */
   void setK(int newK);
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
   /** Populate a JSON value with a description of the current model
    * @param A JSON value to be populated
    */

--- a/src/modelSet.cpp
+++ b/src/modelSet.cpp
@@ -15,9 +15,11 @@
 #include <thread>
 #include "modelSet.h"
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 #include "../dependencies/json/json.h"
-#else
+#endif
+
+#if defined(EMSCRIPTEN)
 #include "emscripten/modelSetEmbindings.h"
 #endif
 
@@ -129,7 +131,7 @@ std::vector<T> modelSet<T>::run(const std::vector<T> &inputVector)
 
 
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 //In emscripten, we do the JSON parsing with native JavaScript
 template<typename T>
 std::vector<T> json2vector(Json::Value json) 

--- a/src/modelSet.h
+++ b/src/modelSet.h
@@ -15,7 +15,7 @@
 #include "neuralNetwork.h"
 #include "knnClassification.h"
 #include "svmClassification.h"
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 #include "../dependencies/json/json.h"
 #endif
 
@@ -48,7 +48,7 @@ protected:
     bool isTrained;
     void threadTrain(std::size_t i, const std::vector<trainingExampleTemplate<T> >& training_set);
 
-#ifndef EMSCRIPTEN //The javascript code will do its own JSON parsing
+#ifndef RAPIDLIB_DISABLE_JSONCPP //The javascript code will do its own JSON parsing
 public:
 
     /** Get a JSON representation of the model

--- a/src/neuralNetwork.cpp
+++ b/src/neuralNetwork.cpp
@@ -328,7 +328,7 @@ T neuralNetwork<T>::getOutBase() const
   return outBase;
 }
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 template<typename T>
 void neuralNetwork<T>::getJSONDescription(Json::Value& jsonModelDescription)
 {

--- a/src/neuralNetwork.h
+++ b/src/neuralNetwork.h
@@ -12,7 +12,7 @@
 #include <vector>
 #include "baseModel.h"
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 #include "../dependencies/json/json.h"
 #endif
 
@@ -81,7 +81,7 @@ public:
     T getOutRange() const;
     T getOutBase() const;
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
     void getJSONDescription(Json::Value& currentModel) override;
 #endif
 

--- a/src/rapidStream.cpp
+++ b/src/rapidStream.cpp
@@ -19,32 +19,28 @@ namespace rapidLib
 {
 
 template<typename T>
-rapidStream<T>::rapidStream(std::size_t window_size) :
-windowSize(window_size),
-windowIndex(0)
+rapidStream<T>::rapidStream(std::size_t window_size) : windowSize(window_size), windowIndex(0)
 {
   circularWindow.resize(windowSize);
   std::fill(circularWindow.begin(), circularWindow.end(), 0);
-  
+
   //Baysian Filter setup
-  bayesFilt.diffusion = powf(10., -2);
-  bayesFilt.jump_rate = powf(10., -10);
-  bayesFilt.mvc[0] = 1.;
+  bayesFilt.diffusion = powf(10.0f, -2);
+  bayesFilt.jump_rate = powf(10.0f, -10);
+  bayesFilt.mvc[0] = 1.0f;
   bayesFilt.init();
 }
 
 template<typename T>
-rapidStream<T>::rapidStream() :
-windowSize(3),
-windowIndex(0)
+rapidStream<T>::rapidStream() : windowSize(3), windowIndex(0)
 {
   circularWindow.resize(windowSize);
   std::fill(circularWindow.begin(), circularWindow.end(), 0);
-  
+
   //Baysian Filter setup
-  bayesFilt.diffusion = powf(10., -2);
-  bayesFilt.jump_rate = powf(10., -10);
-  bayesFilt.mvc[0] = 1.;
+  bayesFilt.diffusion = powf(10.0f, -2);
+  bayesFilt.jump_rate = powf(10.0f, -10);
+  bayesFilt.mvc[0] = 1.0;
   bayesFilt.init();
 }
 
@@ -103,9 +99,10 @@ template<typename T>
 uint32_t rapidStream<T>::numZeroCrossings() const
 {
   uint32_t zeroCrossings {};
-  
+
   //Is the begininng positive, negative, or 0?
   int previous { 1 };
+
   if (circularWindow[windowIndex] < 0)
   {
     previous = -1;
@@ -115,11 +112,11 @@ uint32_t rapidStream<T>::numZeroCrossings() const
     ++zeroCrossings;
     previous = 0;
   }
-  
+
   for (std::size_t i { 1 }; i < windowSize; ++i)
   {
     const std::size_t index { (windowIndex + i) % windowSize};
-    
+
     if (circularWindow[index] < 0 && previous >= 0) //Transition to negative
     {
       ++zeroCrossings;
@@ -135,14 +132,14 @@ uint32_t rapidStream<T>::numZeroCrossings() const
       previous = 0;
     }
   }
+
   return zeroCrossings;
 }
-
 
 template<typename T>
 T rapidStream<T>::sum() const
 {
-  return std::accumulate(circularWindow.begin(), circularWindow.end(), 0);
+  return std::reduce(circularWindow.begin(), circularWindow.end());
 }
 
 template<typename T>
@@ -156,26 +153,28 @@ T rapidStream<T>::standardDeviation() const
 {
   const T newMean { mean() };
   T standardDeviation {};
-  
-  for (auto value : circularWindow)
+
+  for (const auto value : circularWindow)
   {
-    standardDeviation += static_cast<T>(pow(value - newMean, 2));
+    standardDeviation += static_cast<T>(std::pow(value - newMean, 2));
   }
-  return sqrt(standardDeviation / windowSize);
+
+  return std::sqrt(standardDeviation / windowSize);
 }
 
 template<typename T>
 T rapidStream<T>::rms() const
 {
   T rms {};
-  
+
   for (auto value:circularWindow)
   {
     rms += value * value;
   }
-  
+
   rms = rms / windowSize;
-  return sqrt(rms);
+
+  return std::sqrt(rms);
 }
 
 template<typename T>
@@ -211,13 +210,13 @@ template<typename T>
 T rapidStream<T>::minVelocity() const
 {
   T minVel { std::numeric_limits<T>::infinity() };
-  
+
   for (std::size_t i {}; i < windowSize; ++i)
   {
     const T currentVel { calcCurrentVel(i) };
     if (currentVel < minVel)  minVel = currentVel;
   }
-  
+
   return minVel;
 }
 
@@ -225,13 +224,13 @@ template<typename T>
 T rapidStream<T>::maxVelocity() const
 {
   T maxVel { std::numeric_limits<T>::lowest() };
-  
+
   for (std::size_t i {}; i < windowSize; ++i)
   {
     const T currentVel { calcCurrentVel(i) };
     if (currentVel > maxVel) maxVel = currentVel;
   }
-  
+
   return maxVel;
 }
 
@@ -240,7 +239,7 @@ T rapidStream<T>::minAcceleration() const
 {
   T minAccel { std::numeric_limits<T>::infinity() };
   T lastVel { calcCurrentVel(1) };
-  
+
   for (std::size_t i { 2 }; i < windowSize; ++i)
   {
     const T currentVel { calcCurrentVel(i) };
@@ -248,7 +247,7 @@ T rapidStream<T>::minAcceleration() const
     lastVel = currentVel;
     if (currentAccel < minAccel) minAccel = currentAccel;
   }
-  
+
   return minAccel;
 }
 
@@ -257,7 +256,7 @@ T rapidStream<T>::maxAcceleration() const
 {
   T maxAccel { std::numeric_limits<T>::lowest() };
   T lastVel { calcCurrentVel(1) };
-  
+
   for (std::size_t i { 2 }; i < windowSize; ++i)
   {
     const T currentVel { calcCurrentVel(i) };
@@ -265,7 +264,7 @@ T rapidStream<T>::maxAcceleration() const
     lastVel = currentVel;
     if (currentAccel > maxAccel) maxAccel = currentAccel;
   }
-  
+
   return maxAccel;
 }
 

--- a/src/rapidStream.cpp
+++ b/src/rapidStream.cpp
@@ -139,7 +139,7 @@ uint32_t rapidStream<T>::numZeroCrossings() const
 template<typename T>
 T rapidStream<T>::sum() const
 {
-  return std::reduce(circularWindow.begin(), circularWindow.end());
+  return std::accumulate(circularWindow.begin(), circularWindow.end(), T{});
 }
 
 template<typename T>

--- a/src/searchWindow.cpp
+++ b/src/searchWindow.cpp
@@ -11,18 +11,19 @@
 #include "searchWindow.h"
 
 template<typename T>
-searchWindow<T>::searchWindow(const std::size_t seriesXSize, const std::size_t seriesYSize, const warpPath &shrunkenWarpPath, const int searchRadius) : minMaxValues(seriesXSize, std::make_pair(-1, 0)), maxY(seriesYSize - 1)
+searchWindow<T>::searchWindow(const std::size_t seriesXSize, const std::size_t seriesYSize, const warpPath& shrunkenWarpPath, const int searchRadius) : minMaxValues(seriesXSize, std::make_pair(-1, 0)),
+    maxY(static_cast<int>(seriesYSize - 1))
 {
   //Current location of higher resolution path
-  std::pair<int, int> currentIndex = shrunkenWarpPath.indices[0];
-  
+  std::pair<int, int> currentIndex { shrunkenWarpPath.indices[0] };
+
   //Last evaluated part of low resolution path
-  std::pair<int, int> lastWarped = std::make_pair(std::numeric_limits<int>::max(), std::numeric_limits<int>::max());
-  
-  int blockSize = 2; //TODO: something other than 2? Different for x and y?
-  
+  std::pair<int, int> lastWarped { std::make_pair(std::numeric_limits<int>::max(), std::numeric_limits<int>::max()) };
+
+  const int blockSize { 2 }; //TODO: something other than 2? Different for x and y?
+
   //project each part of the low-res path to high res cells
-  for ( auto &xyIndex : shrunkenWarpPath.indices)
+  for (const auto &xyIndex : shrunkenWarpPath.indices)
   {
     if (xyIndex.first > lastWarped.first) currentIndex.first += blockSize;
     if (xyIndex.second > lastWarped.second) currentIndex.second += blockSize;
@@ -32,7 +33,7 @@ searchWindow<T>::searchWindow(const std::size_t seriesXSize, const std::size_t s
       markVisited(currentIndex.first, currentIndex.second - 1);
     }
     
-    for (int j = 0; j < blockSize; ++j)
+    for (int j {}; j < blockSize; ++j)
     {
       markVisited(currentIndex.first + j, currentIndex.second);
       markVisited(currentIndex.first + j, currentIndex.second + blockSize - 1); //TODO: These are redundant?
@@ -57,9 +58,13 @@ inline void searchWindow<T>::markVisited(std::size_t col, std::size_t row)
     {
       minMaxValues[col].first = row;
       minMaxValues[col].second = row;
-    } else if (minMaxValues[col].first > row) {
+    }
+    else if (minMaxValues[col].first > row)
+    {
       minMaxValues[col].first = row;
-    } else if (minMaxValues[col].second < row) {
+    }
+    else if (minMaxValues[col].second < row)
+    {
       minMaxValues[col].second = row;
     }
   }
@@ -71,133 +76,141 @@ void searchWindow<T>::expandWindow(int radius)
   if (radius > 0)
   {
     //Add all cells in the current window to a vector.
-    std::vector<std::pair<int, int>> windowCells;
+    std::vector<std::pair<int, int>> windowCells {};
+
     for (int currentX = 0; currentX < minMaxValues.size(); ++currentX)
     {
-      for (std::size_t currentY = minMaxValues[currentX].first; currentY <= minMaxValues[currentX].second; ++currentY)
+      for (std::size_t currentY { minMaxValues[currentX].first}; currentY <= minMaxValues[currentX].second; ++currentY)
       {
         windowCells.push_back(std::make_pair(currentX, currentY));
       }
     }
     
-    int maxX = int(minMaxValues.size() - 1);
-    
-    for (auto &currentCell : windowCells)
+    const int maxX { static_cast<int>(minMaxValues.size() - 1) };
+
+    for (const auto &currentCell : windowCells)
     {
       if (currentCell.first != 0 && currentCell.second != maxY) //move to upper left if possible
       {
         //expand until edges are met
-        int targetX = currentCell.first - radius;
-        int targetY = currentCell.second + radius;
-        
+        const int targetX { currentCell.first - radius };
+        const int targetY { currentCell.second + radius };
+
         if (targetX >= 0 && targetY <= maxY)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = std::max(0 - targetX, targetY - int(maxY)); //FIXME: ints? size_t?
+          const int cellsPastEdge { std::max(0 - targetX, targetY - maxY) };
           markVisited(targetX + cellsPastEdge, targetY + cellsPastEdge);
         }
       }
       
       if (currentCell.second != maxY) //move up if possible
       {
-        int targetX = currentCell.first;
-        int targetY = currentCell.second + radius;
+        const int targetX { currentCell.first };
+        const int targetY { currentCell.second + radius };
         if (targetY <= maxY)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = targetY - int(maxY);
+          const int cellsPastEdge { targetY - int(maxY) };
           markVisited(targetX, targetY - cellsPastEdge);
         }
       }
       
       if (currentCell.first != maxX && currentCell.second != maxY) //move upper right if possible
       {
-        std::size_t targetX = currentCell.first + radius;
-        std::size_t targetY = currentCell.second + radius;
+        const int targetX { currentCell.first + radius };
+        const int targetY { currentCell.second + radius };
         if (targetX <= maxX && targetY <= maxY)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          std::size_t cellsPastEdge = std::max(targetX - maxX, targetY - maxY);
+          const int cellsPastEdge { std::max(targetX - maxX, targetY - maxY) };
           markVisited(targetX - cellsPastEdge, targetY - cellsPastEdge);
         }
       }
       
       if (currentCell.first != 0) //move left if possible
       {
-        int targetX = currentCell.first - radius;
-        std::size_t targetY = currentCell.second;
+        const int targetX { currentCell.first - radius };
+        const int targetY { currentCell.second };
+
         if (targetX != 0)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = (0 - targetX);
+          const int cellsPastEdge { 0 - targetX };
           markVisited(targetX + cellsPastEdge, targetY);
         }
       }
       
-      if (currentCell.first != maxX) { //move right if possible
-        int targetX = currentCell.first + radius;
-        int targetY = currentCell.second;
+      if (currentCell.first != maxX) //move right if possible
+      {
+        const int targetX { currentCell.first + radius};
+        const int targetY { currentCell.second };
         if (targetX <= maxX)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = (targetX - maxX);
+          const int cellsPastEdge { targetX - maxX };
           markVisited(targetX - cellsPastEdge, targetY);
         }
       }
       
       if (currentCell.first != 0 && currentCell.second != 0) { //move to lower left if possible
-        int targetX = currentCell.first - radius;
-        int targetY = currentCell.second - radius;
-        
+        const int targetX { currentCell.first - radius };
+        const int targetY { currentCell.second - radius };
+
         if (targetX >= 0 && targetY >= 0)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = std::max(0 - targetX, 0 - targetY);
+          const int cellsPastEdge { std::max(0 - targetX, 0 - targetY) };
           markVisited(targetX + cellsPastEdge, targetY + cellsPastEdge);
         }
       }
       
       if (currentCell.second != 0) //move down if possible
       {
-        int targetX = currentCell.first;
-        int targetY = currentCell.second - radius;
+        const int targetX { currentCell.first };
+        const int targetY { currentCell.second - radius };
+
         if (targetY >= 0)
         {
           markVisited(targetX, targetY);
         }
         else
         {
-          int cellsPastEdge = 0 - targetY;
+          const int cellsPastEdge { 0 - targetY };
           markVisited(targetX, targetY + cellsPastEdge);
         }
       }
       
       if (currentCell.first != maxX && currentCell.second != 0) //move lower right if possible
       {
-        int targetX = currentCell.first + radius;
-        int targetY = currentCell.second - radius;
-        if (targetX <= maxX && targetY >= 0) {
+        const int targetX { currentCell.first + radius };
+        const int targetY { currentCell.second - radius };
+
+        if (targetX <= maxX && targetY >= 0)
+        {
           markVisited(targetX, targetY);
-        } else {
-          int cellsPastEdge = std::max(targetX - maxX, 0 - targetY);
+        }
+        else
+        {
+          const int cellsPastEdge { std::max(targetX - maxX, 0 - targetY) };
           markVisited(targetX - cellsPastEdge, targetY + cellsPastEdge);
         }
       }

--- a/src/searchWindow.h
+++ b/src/searchWindow.h
@@ -19,17 +19,18 @@ template<typename T>
 class searchWindow
 {
 public:
-    searchWindow(const std::size_t seriesXSize,
-                 const std::size_t seriesYSize,
-                 const warpPath &shrunkenWarpPath,
-                 const int searchRadius);
-    
-     std::vector< std::pair<std::size_t, std::size_t> > minMaxValues;
-    
+  searchWindow(const std::size_t seriesXSize,
+               const std::size_t seriesYSize,
+               const warpPath &shrunkenWarpPath,
+               const int searchRadius);
+
+  std::vector<std::pair<std::size_t, std::size_t>> minMaxValues {};
+
 private:
-    std::size_t maxY;
-    inline void markVisited(std::size_t col, std::size_t row);
-    void expandWindow(int searchRadius);
+  inline void markVisited(std::size_t col, std::size_t row);
+  void expandWindow(int searchRadius);
+
+  int maxY {};
 };
 
 #endif

--- a/src/svmClassification.cpp
+++ b/src/svmClassification.cpp
@@ -261,7 +261,7 @@ std::vector<size_t> svmClassification<T>::getWhichInputs() const {
     return returnVec;
 };
 
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
 template<typename T>
 void svmClassification<T>::getJSONDescription(Json::Value &currentModel){
     

--- a/src/svmClassification.h
+++ b/src/svmClassification.h
@@ -113,7 +113,7 @@ public:
     size_t getNumInputs() const override;
     std::vector<size_t> getWhichInputs() const override;
         
-#ifndef EMSCRIPTEN
+#ifndef RAPIDLIB_DISABLE_JSONCPP
     void getJSONDescription(Json::Value &currentModel) override;
 #endif
     

--- a/src/warpPath.h
+++ b/src/warpPath.h
@@ -24,17 +24,15 @@ public:
      */
     void add(std::size_t x, std::size_t y);
     
-    std::vector< std::pair<std::size_t, std::size_t> > indices;
+    std::vector<std::pair<std::size_t, std::size_t>> indices;
 };
 
 /** return struct holding a warp path and the cost of that path */
 template<typename T>
 struct warpInfo 
 {
-public:
     warpPath path;
     T cost;
-    
 };
 
 #endif


### PR DESCRIPTION
If a software tries to integrate rapidlib but already uses jsoncpp, then
this is undefined behaviour which gets flagged by addresssanitizer for instance.

I encountered this while trying to integrate RapidLib with https://ossia.io :
ossia integrates sh4lt which is a completely different package for sharing
video frames across processes on Linux.
sh4lt also uses jsoncpp as part of its implementation thus jsoncpp symbols are defined twice
(and the unlucky software crashes on startup).
